### PR TITLE
fix: set correct permissions for keycloak start script

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -22,6 +22,4 @@ RUN /opt/keycloak/bin/kc.sh show-config
 FROM quay.io/keycloak/keycloak:22.0
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 
-COPY ./scripts/kcWithAutoImport.sh /opt/keycloak/bin/kcWithAutoImport.sh
-
 ENTRYPOINT [ "/opt/keycloak/bin/kcWithAutoImport.sh" ]

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -8,6 +8,14 @@ ENV KC_METRICS_ENABLED=true
 ENV KC_DB=postgres
 
 WORKDIR /opt/keycloak
+
+# Install start script
+USER root
+COPY ./scripts/kcWithAutoImport.sh /opt/keycloak/bin/kcWithAutoImport.sh
+RUN chmod +x /opt/keycloak/bin/kcWithAutoImport.sh && chown keycloak:root /opt/keycloak/bin/kcWithAutoImport.sh
+
+USER keycloak
+
 RUN /opt/keycloak/bin/kc.sh build --db=postgres
 RUN /opt/keycloak/bin/kc.sh show-config
 


### PR DESCRIPTION
The keycloak docker container uses the user `keycloak` to run the server. Hence we have to make sure, that the entrypoint script is readable by keycloak user.